### PR TITLE
Make compatible with kitspace.org

### DIFF
--- a/1-click-bom.csv
+++ b/1-click-bom.csv
@@ -1,4 +1,4 @@
-References,Qty,Description,Manufacturer,MPN,Digikey,Mouser,RS,Newark,Farnell
-"J2, J1",2,"pin header, 1x08, 2.54mm pitch, single row",Molex,901-20-0128,,,,,
-C1,1,Capacitor SMD 0603 100uF,,,,,,,
-U1,1,BM14B(0.8)-24DS-0.4V(53),Hirose,BM14B(0.8)-24DS-0.4V(53),H122178DKR-ND,798BM14B0824DS04V53,1620941,,2724957
+References,Qty,Description,Manufacturer,MPN,Manufacturer,MPN,Digikey,Mouser,RS,Newark,Farnell
+"J2, J1",2,"pin header, 1x08, 2.54mm pitch, single row",Molex,901-20-0128,Molex,90120-0128,WM8078-ND,538901200128,6705041P,,3049365
+C1,1,Capacitor SMD 0603 100nF,Yageo,CC0603KRX7R9BB104,Murata,GRM188R71H104KA93D,311-1344-1-ND,603CC603KRX7R9BB104,6242480P,,1362556
+U1,1,BM14B(0.8)-24DS-0.4V(53),Hirose,BM14B(0.8)-24DS-0.4V(53),,,H122178DKR-ND,798BM14B0824DS04V53,1620941,,2724957

--- a/1-click-bom.csv
+++ b/1-click-bom.csv
@@ -1,0 +1,4 @@
+References,Qty,Description,Manufacturer,MPN,Digikey,Mouser,RS,Newark,Farnell
+"J2, J1",2,"pin header, 1x08, 2.54mm pitch, single row",Molex,901-20-0128,,,,,
+C1,1,Capacitor SMD 0603 100uF,,,,,,,
+U1,1,BM14B(0.8)-24DS-0.4V(53),Hirose,BM14B(0.8)-24DS-0.4V(53),H122178DKR-ND,798BM14B0824DS04V53,1620941,,2724957

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,3 +1,4 @@
 bom: 1-click-bom.csv
 gerbers: gerber/
 summary: A very simple board breaking out the Q10 keyboard connector.
+site: https://github.com/users/arturo182/sponsorship

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,3 @@
+bom: 1-click-bom.csv
+gerbers: gerber/
+summary: A very simple board breaking out the Q10 keyboard connector.


### PR DESCRIPTION
Hey, I added the files necessary to add your project on [kitspace.org](https://kitspace.org). Here is a [preview](http://add-bbq10kbd.preview.kitspace.org/boards/github.com/kitspace-forks/bbq10kbd_breakout/) of what it will look like. If you are happy to add it, just merge these changes. If added the Kitspace page will stay in sync with the Github repo (with a max delay of 24hrs). 

This BOM is quite simple, but if you like the idea of adding your projects I could take a look at a more complicated one where the 1-click-BOM functionality will be more worth it. 